### PR TITLE
Adds '/blogs' route for blogs templates

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -18,21 +18,21 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       let slug = permalink
 
       if (!slug) {
-        slug = `/${relativePath.replace('.md', '')}/`
+        slug = `/blogs/${relativePath.replace('.md', '')}/`
       }
 
       // Used to generate URL to view this content.
       createNodeField({
         node,
         name: 'slug',
-        value: slug || ''
+        value: slug || '',
       })
 
       // Used to determine a page layout.
       createNodeField({
         node,
         name: 'layout',
-        value: layout || ''
+        value: layout || '',
       })
     }
   }
@@ -78,8 +78,8 @@ exports.createPages = async ({ graphql, actions }) => {
       component: path.resolve(`./src/templates/${layout || 'page'}.tsx`),
       context: {
         // Data passed to context is available in page queries as GraphQL variables.
-        slug
-      }
+        slug,
+      },
     })
   })
 }


### PR DESCRIPTION
This PR implements separate route for blogs templates. The blogs are available at `/blogs` route.