### PR TITLE
Add header links and toc for markdown contents

### DIFF
--- a/components/navbar/index.tsx
+++ b/components/navbar/index.tsx
@@ -114,7 +114,7 @@ const Navbar: FC = () => {
     <Box
       as="header"
       position="sticky"
-      top="80px"
+      top={0}
       zIndex={1}
       bg={navbarSectionBgColor[colorMode]}
       color={navbarSectionColor[colorMode]}

--- a/components/social-links/index.tsx
+++ b/components/social-links/index.tsx
@@ -20,8 +20,6 @@ const SocialLinks: FC = () => {
       bg={cardBgColor[colorMode]}
       color={cardColor[colorMode]}
       p={4}
-      position="sticky"
-      top={0}
       zIndex={1}
     >
       <Box maxW="6xl" mx="auto" d="flex" justifyContent="space-between">

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,6 @@ const withSourceMaps = require("@zeit/next-source-maps")();
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 const readingTime = require("reading-time");
-const mdxPrism = require("mdx-prism");
 const withMdxEnhanced = require("next-mdx-enhanced");
 
 const isProd = process.env.NODE_ENV === "production";
@@ -16,11 +15,11 @@ module.exports = withSourceMaps(
     layoutPath: "./components/layouts/articles/show",
     defaultLayout: true,
     remarkPlugins: [
-      require("remark-autolink-headings"),
       require("remark-slug"),
       require("remark-code-titles"),
+      require("remark-toc"),
     ],
-    rehypePlugins: [mdxPrism],
+    rehypePlugins: [require("rehype-autolink-headings"), require("mdx-prism")],
     extendFrontMatter: {
       process: (mdxContent) => ({
         wordCount: mdxContent.split(/\s+/gu).length,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@chakra-ui/core": "^0.8.0",
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",
+    "@jsdevtools/rehype-toc": "^3.0.1",
     "@sentry/node": "^5.17.0",
     "@sentry/webpack-plugin": "^1.11.1",
     "babel-plugin-import-glob-array": "^0.2.0",
@@ -39,9 +40,10 @@
     "reading-time": "^1.2.0",
     "recoil": "^0.0.7",
     "rehype": "^11.0.0",
-    "remark-autolink-headings": "^6.0.0",
+    "rehype-autolink-headings": "^3.0.0",
     "remark-code-titles": "^0.1.1",
-    "remark-slug": "^6.0.0"
+    "remark-slug": "^6.0.0",
+    "remark-toc": "^7.0.0"
   },
   "devDependencies": {
     "@sentry/browser": "^5.17.0",

--- a/pages/articles/how-to-authenticate-your-next-js-application-using-open-source-headless-cms-strapi.mdx
+++ b/pages/articles/how-to-authenticate-your-next-js-application-using-open-source-headless-cms-strapi.mdx
@@ -8,6 +8,8 @@ description: "Learn how to authenticate a front-end application using Next.js an
 
 > In this tutorial, we'll learn about how to authenticate a front-end application using [Next.js](https://nextjs.org/) and [Strapi](https://strapi.io/).
 
+## Table of Contents
+
 We'll start from where we finished in [How to Automate the Backend stuffs with Open Source Headless CMS Strapi and Docker](/blog/how-to-automate-the-backend-stuffs-with-open-source-headless-cms-strapi-and-docker). The starter code is available on [Github](https://github.com/ghoshnirmalya/product-hunt-clone-using-strapi-react-next-docker/commit/2b9c0b2440b17bb45d2dd0612d70ab6b0c9a863a). The code for Strapi project is available in the [backend](https://github.com/ghoshnirmalya/product-hunt-clone-using-strapi-react-next-docker/tree/master/backend) directory and the code for Next.js is available in the [frontend](https://github.com/ghoshnirmalya/product-hunt-clone-using-strapi-react-next-docker/tree/master/frontend) directory.
 
 ## Getting started with authentication

--- a/pages/articles/how-to-automate-the-backend-stuffs-with-open-source-headless-cms-strapi-and-docker.mdx
+++ b/pages/articles/how-to-automate-the-backend-stuffs-with-open-source-headless-cms-strapi-and-docker.mdx
@@ -14,6 +14,8 @@ As a result, I was trying to find an alternate tool which would take care of the
 
 > I'll also write about [Hasura](https://hasura.io/) which connects to our databases & microservices and instantly gives us a production-ready GraphQL API. It's another tool that I found which takes care of the back-end.
 
+## Table of Contents
+
 ## Getting started with Strapi
 
 We'll be using the [Docker version of Strapi](https://github.com/strapi/strapi-docker). This will help us manage the database inside a containerized environment. In case our database gets corrupted, we can remove the container and re-build it again. There are many other advantages of using Docker. Instructions for installing Docker can be obtained from the [Docker documentation](https://docs.docker.com/v17.09/engine/installation/). Once the Docker installation is complete, we can proceed towards installing Strapi. We'll be using Postgres as our database. But, we can also use [SQLite](https://strapi.io/documentation/3.0.0-beta.x/guides/databases.html#sqlite-installation), [MongoDB](https://strapi.io/documentation/3.0.0-beta.x/guides/databases.html#mongodb-installation), MySQL and MariaDB. Example applications using these databases are present in the [Strapi Docker repository](https://github.com/strapi/strapi-docker/tree/master/examples).

--- a/pages/articles/integrating-tailwind-css-with-next-js.mdx
+++ b/pages/articles/integrating-tailwind-css-with-next-js.mdx
@@ -8,6 +8,8 @@ description: "Learn how to use TailwindCSS with Next.js to build maintainable fr
 
 > In this tutorial, we'll learn how to integrate [TailwindCSS](https://tailwindcss.com/) with [Next.js](https://nextjs.org/).
 
+## Table of Contents
+
 ## What is Next.js?
 
 [Next.js](https://nextjs.org/) is a React framework which provides Server-Side Rendering out of box. It's a very popular Node.js framework with [over 43k stars on Github](https://github.com/zeit/next.js). It provides a [several features](https://nextjs.org/#features) like [Server-Side rendering](https://nextjs.org/features/server-side-rendering), [Static Exporting](https://nextjs.org/features/static-exporting), [CSS-in-JS](https://nextjs.org/features/css-in-js), etc.

--- a/pages/articles/understanding-component-oriented-styling-using-styletron.mdx
+++ b/pages/articles/understanding-component-oriented-styling-using-styletron.mdx
@@ -8,6 +8,8 @@ description: "Learn how to style your React components using Styletron."
 
 > In this tutorial, we'll learn about the problems with styling [React](https://reactjs.org/) applications and how we can solve them using [Styletron](https://www.styletron.org/).
 
+## Table of Contents
+
 I've been using [React](https://reactjs.org/) for quite some time now. In that time, the one thing which I've felt is most difficult while creating React applications is **how to style them in a maintainable manner**. There are various ways in which we can styles applications:
 
 - [Styled components](https://styled-components.com/)

--- a/pages/articles/using-mirage-js-to-jumpstart-your-frontend-development.mdx
+++ b/pages/articles/using-mirage-js-to-jumpstart-your-frontend-development.mdx
@@ -8,6 +8,8 @@ description: "Learn how to build front-end applications without any back-end API
 
 > In this article, we'll learn about how to build a front-end application without back-end APIs using [Mirage](https://miragejs.com/).
 
+## Table of Contents
+
 As a front-end developer, I've faced multiple issues while integrating front-end applications with back-end APIs. Most of the time, the issue that I've faced was that the back-end isn't ready yet and as a result, I had to either wait for it to be completed or work with static mock data. The problem with working with static mock data is that we won't be able to create, update or delete any data as it isn't persistent data. We can only read data from a sample `.json` file and import it to test our front-end application. As a result, we'll never be sure if our application is working as expected until and unless the whole back-end is ready.
 
 Recently, I came across [Mirage](https://miragejs.com/) which is an API mocking library that lets us build, test and share a complete working JavaScript application without having to rely on any backend services. Unlike other mocking libraries, Mirage makes it easy to recreate dynamic scenarios, the kind that are typically only possible when using a real production server.

--- a/pages/articles/what-is-tailwind-css-and-what-problems-does-this-new-css-framework-solve-for-us.mdx
+++ b/pages/articles/what-is-tailwind-css-and-what-problems-does-this-new-css-framework-solve-for-us.mdx
@@ -8,6 +8,8 @@ description: "Learn how to build components and design-systems using TailwindCSS
 
 > In this tutorial, we'll learn what is the problem with component-based styling and why we need utility-based styles. Also, we'll explore [TailwindCSS](https://tailwindcss.com/) which is a utility-first CSS framework. We'll also learn about how to install, configure and learn TailwindCSS with a [React](https://reactjs.org/) app.
 
+## Table of Contents
+
 As a front-end developer, I've worked on projects having a large codebase. The most common problem that arises after a prolonged period of development is managing styles and this problem is very [common](https://css-tricks.com/oh-no-stylesheet-grows-grows-grows-append-stylesheet-problem/). Although we've many CSS architectures like [Atomic CSS](https://acss.io/), [BEM](http://getbem.com/), [ITCSS](https://itcss.io/), [SMACSS](http://smacss.com/), etc., we still have the problem with managing them. Added to this, we can also have [CSS performance issues](https://csswizardry.com/2018/11/css-and-network-performance/) as well.
 
 In the codebase which I was working on, we started with BEM for writing HTML and CSS. In a sub-module of that project, we'd used [Bootstrap](https://getbootstrap.com/). Also, in some legacy code of that codebase, we've custom CSS that wasn't following any convention.

--- a/styles/code.ts
+++ b/styles/code.ts
@@ -2,15 +2,38 @@ import { css } from "@emotion/core";
 import { theme } from "@chakra-ui/core";
 
 const prismBaseTheme = css`
-  .article h2 {
-    margin: ${theme.space[16]} 0 ${theme.space[4]};
+  .article > h2 {
+    padding: ${theme.space[24]} 0 ${theme.space[4]};
     font-size: ${theme.fontSizes["2xl"]};
     font-weight: ${theme.fontWeights.bold};
   }
 
-  .article p {
+  .article > p {
     margin: ${theme.space[4]} 0 ${theme.space[8]};
     font-size: ${theme.fontSizes["lg"]};
+  }
+
+  .article > #table-of-contents + ul {
+    padding: ${theme.space[6]};
+    list-style-type: decimal;
+  }
+
+  .article > #table-of-contents + ul > li {
+    margin-bottom: ${theme.space[4]};
+  }
+
+  .article > #table-of-contents + ul > li > a {
+    font-size: ${theme.fontSizes["lg"]};
+  }
+
+  .article > #table-of-contents + ul > li > a:hover {
+    text-decoration: underline;
+  }
+
+  .article .icon.icon-link::before {
+    content: "#";
+    margin-right: ${theme.space[2]};
+    display: inline-flex;
   }
 
   code[class*="language-"],

--- a/vendor.d.ts
+++ b/vendor.d.ts
@@ -1,8 +1,8 @@
 import IArticle from "types/article";
 
-declare module "remark-autolink-headings";
 declare module "remark-slug";
 declare module "remark-code-titles";
+declare module "rehype-autolink-headings";
 declare module "next-mdx-enhanced";
 declare module "mdx-prism";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,6 +1269,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@jsdevtools/rehype-toc@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/rehype-toc/-/rehype-toc-3.0.1.tgz#94dd7df9fe97a4de17285b4123a2b184a60ffe9a"
+  integrity sha512-HzLFICsh4PBwOb2PpGh8GN2uF20d+0KnfIkPAf251Lr+EwUtwS0IYyT9vMtRAR6Gi24eqRnXFRJOzLpRr4b4kg==
+
 "@mdx-js/loader@^1.6.1":
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.5.tgz#f2826c79f18cbc6b502dd5722d7e7101e5658dbb"
@@ -1575,7 +1580,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/mdast@^3.0.0":
+"@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
   integrity sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
@@ -3486,7 +3491,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0:
+extend@^3.0.0, extend@^3.0.1, extend@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -3720,7 +3725,7 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
-github-slugger@^1.0.0:
+github-slugger@^1.0.0, github-slugger@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.3.0.tgz#9bd0a95c5efdfc46005e82a906ef8e2a059124c9"
   integrity sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==
@@ -3901,6 +3906,11 @@ hast-util-from-parse5@^6.0.0:
     property-information "^5.0.0"
     vfile "^4.0.0"
     web-namespaces "^1.0.0"
+
+hast-util-has-property@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz#9f137565fad6082524b382c1e7d7d33ca5059f36"
+  integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
 
 hast-util-is-element@^1.0.0:
   version "1.0.4"
@@ -4771,10 +4781,23 @@ mdast-util-to-hast@9.1.0:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
-mdast-util-to-string@^1.0.0:
+mdast-util-to-string@^1.0.0, mdast-util-to-string@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
   integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
+
+mdast-util-toc@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-toc/-/mdast-util-toc-5.0.3.tgz#5fb1503e3655688929d596799a6910cc6548e420"
+  integrity sha512-A3xzcgC1XFHK0+abFmbINOxjwo7Bi0Nsfp3yTgTy5JHo2q2V6YZ5BVJreDWoK3szcLlSMvHqe8WPbjY50wAkow==
+  dependencies:
+    "@types/mdast" "^3.0.3"
+    "@types/unist" "^2.0.3"
+    extend "^3.0.2"
+    github-slugger "^1.2.1"
+    mdast-util-to-string "^1.0.5"
+    unist-util-is "^4.0.0"
+    unist-util-visit "^2.0.0"
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -6329,6 +6352,16 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+rehype-autolink-headings@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-autolink-headings/-/rehype-autolink-headings-3.0.0.tgz#8e771395690d02570b507ba430bcaf081a0a9c14"
+  integrity sha512-Kit6caYCGvH7OSeXgEq0F4b4vXFg92owru/26ckSLCODjvbD4TogAOvYvzcvkaeIO0uDpnmCg0MsmHJtHXBvyQ==
+  dependencies:
+    extend "^3.0.1"
+    hast-util-has-property "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    unist-util-visit "^2.0.0"
+
 rehype-parse@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-7.0.0.tgz#7a56fadc0a7248572398c458d2aebf4378339965"
@@ -6352,14 +6385,6 @@ rehype@^11.0.0:
     rehype-parse "^7.0.0"
     rehype-stringify "^8.0.0"
     unified "^9.0.0"
-
-remark-autolink-headings@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/remark-autolink-headings/-/remark-autolink-headings-6.0.0.tgz#86ec9c79f88fb911c96f8af9e0351d19453062f7"
-  integrity sha512-IlwzsSgw14EZ9ZNd+Ct/0Kn/DrFaAg2NvSvqSKnoRFTXO5Bmb7tL2Fk/Yw93OD7kban9tqpMRnNcpQB9O2aWvQ==
-  dependencies:
-    extend "^3.0.0"
-    unist-util-visit "^2.0.0"
 
 remark-code-titles@^0.1.1:
   version "0.1.1"
@@ -6424,6 +6449,14 @@ remark-squeeze-paragraphs@4.0.0:
   integrity sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
+
+remark-toc@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/remark-toc/-/remark-toc-7.0.0.tgz#d0f455b63fed00cccfe08050d75c2abef4508e38"
+  integrity sha512-NyW/W7ttlj003eFXeIgq7eV2bffTQuO48PyC9zbh/RhTA/QaHJOAgJ4qvaRwKAVMWSBIh4W/5nZFWQ4rceV3fw==
+  dependencies:
+    "@types/unist" "^2.0.3"
+    mdast-util-toc "^5.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
**Details**
1. Adds and implements `rehype-autolink-headings` for adding links to heading in markdown contents. See the screenshot below:

|Screenshot|
|-|
|<img width="763" alt="Screenshot 2020-06-12 at 11 05 36 PM" src="https://user-images.githubusercontent.com/6391763/84530888-499fbf80-ad01-11ea-85e2-cdaaf21ea563.png">|

2. Adds and implements `remark-toc` for adding **Table of Contents** in markdown contents. See the screenshot below:

|Screenshot|
|-|
|<img width="530" alt="Screenshot 2020-06-12 at 11 07 09 PM" src="https://user-images.githubusercontent.com/6391763/84530986-78b63100-ad01-11ea-9dd2-d5caaf60eaf2.png">|